### PR TITLE
Fix issue #8

### DIFF
--- a/starter/lib/home_page.dart
+++ b/starter/lib/home_page.dart
@@ -1,0 +1,89 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:awesome_drawing_quiz/app_theme.dart';
+import 'package:flutter/material.dart';
+
+// TODO: Import google_mobile_ads.dart
+
+class HomeRoute extends StatefulWidget {
+  @override
+  _HomeRouteState createState() => _HomeRouteState();
+}
+
+class _HomeRouteState extends State<HomeRoute> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppTheme.primary,
+      body: FutureBuilder<void>(
+        future: _initGoogleMobileAds(),
+        builder: (BuildContext context, AsyncSnapshot<void> snapshot) {
+          return Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Text(
+                  "Awesome Drawing Quiz!",
+                  style: TextStyle(
+                    fontSize: 32,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 72),
+                ),
+                if (snapshot.hasData)
+                  ElevatedButton(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 48.0,
+                        vertical: 12.0,
+                      ),
+                      child: Text('Let\'s get started!'),
+                    ),
+                    style: ElevatedButton.styleFrom(
+                      primary: Theme.of(context).accentColor,
+                    ),
+                    onPressed: () {
+                      Navigator.of(context).pushNamed('/game');
+                    },
+                  )
+                else if (snapshot.hasError)
+                  Icon(
+                    Icons.error_outline,
+                    color: Colors.red,
+                    size: 60,
+                  )
+                else
+                  SizedBox(
+                    child: CircularProgressIndicator(),
+                    width: 48,
+                    height: 48,
+                  ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  // TODO: Change return type to Future<InitializationStatus>
+  Future<void> _initGoogleMobileAds() {
+    // TODO: Initialize Google Mobile Ads SDK
+    return Future.value({});
+  }
+}

--- a/starter/lib/home_page.dart
+++ b/starter/lib/home_page.dart
@@ -17,12 +17,12 @@ import 'package:flutter/material.dart';
 
 // TODO: Import google_mobile_ads.dart
 
-class HomeRoute extends StatefulWidget {
+class HomePage extends StatefulWidget {
   @override
-  _HomeRouteState createState() => _HomeRouteState();
+  _HomePageState createState() => _HomePageState();
 }
 
-class _HomeRouteState extends State<HomeRoute> {
+class _HomePageState extends State<HomePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(

--- a/starter/lib/main.dart
+++ b/starter/lib/main.dart
@@ -14,7 +14,7 @@
 
 import 'package:awesome_drawing_quiz/app_theme.dart';
 import 'package:awesome_drawing_quiz/game_route.dart';
-import 'package:awesome_drawing_quiz/home_route.dart';
+import 'package:awesome_drawing_quiz/home_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:google_fonts/google_fonts.dart';

--- a/starter/lib/main.dart
+++ b/starter/lib/main.dart
@@ -29,9 +29,9 @@ void main() async {
 
   runApp(
     MaterialApp(
-      home: HomeRoute(),
+      home: HomePage(),
       routes: <String, WidgetBuilder>{
-        '/home': (BuildContext context) => new HomeRoute(),
+        '/home': (BuildContext context) => new HomePage(),
         '/game': (BuildContext context) => new GameRoute()
       },
       theme: ThemeData(


### PR DESCRIPTION
In the codelab the instruction:

 "_Before loading ads, you need to initialize the Google Mobile Ads SDK. Open the lib/**home_page.dart** file, and modify..."_

has an error. The file home_page.dart doesn't exist. 

Solution:

1) Rename the file `home_route.dart` to `home_page.dart`
2) Change the import on main.dart to reference the new file name, from `home_route.dart` to `home_page.dart`